### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used. 

### DIFF
--- a/src/main/java/com/grapeshot/halfnes/CPU.java
+++ b/src/main/java/com/grapeshot/halfnes/CPU.java
@@ -5,8 +5,11 @@
 package com.grapeshot.halfnes;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 public final class CPU {
 
@@ -41,7 +44,7 @@ public final class CPU {
 
         ONCARRY, ALWAYS; //type of dummy read
     }
-    FileWriter w; //debug log writer
+    OutputStreamWriter w; //debug log writer
 
     public CPU(final CPURAM cpuram) {
         ram = cpuram;
@@ -54,7 +57,7 @@ public final class CPU {
     public void startLog() {
         logging = true;
         try {
-            w = new FileWriter(new File("nesdebug.txt"));
+            w = new OutputStreamWriter(new FileOutputStream(new File("nesdebug.txt")), StandardCharsets.UTF_8); 
         } catch (IOException e) {
             System.err.println("Cannot create debug log" + e.getLocalizedMessage());
         }
@@ -63,7 +66,7 @@ public final class CPU {
     public void startLog(String path) {
         logging = true;
         try {
-            w = new FileWriter(new File(path));
+            w = new OutputStreamWriter(new FileOutputStream(new File(path)), StandardCharsets.UTF_8); 
         } catch (IOException e) {
             System.err.println("Cannot create debug log" + e.getLocalizedMessage());
         }

--- a/src/main/java/com/grapeshot/halfnes/JInputHelper.java
+++ b/src/main/java/com/grapeshot/halfnes/JInputHelper.java
@@ -2,6 +2,7 @@ package com.grapeshot.halfnes;
 
 import java.io.*;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -96,7 +97,7 @@ public enum JInputHelper {
     private static boolean isWindows10() {
         try {
             Process process = Runtime.getRuntime().exec("cmd.exe /c ver");
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
             bufferedReader.readLine();
             String line = bufferedReader.readLine();
             process.waitFor();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed