### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/grapeshot/halfnes/FileUtils.java
+++ b/src/main/java/com/grapeshot/halfnes/FileUtils.java
@@ -12,6 +12,8 @@ import java.io.*;
  * @author Andrew
  */
 public class FileUtils {
+    
+    private FileUtils() {}
 
     public static String getExtension(final File f) {
         return getExtension(f.getName());

--- a/src/main/java/com/grapeshot/halfnes/HeadlessNES.java
+++ b/src/main/java/com/grapeshot/halfnes/HeadlessNES.java
@@ -11,6 +11,9 @@ import java.awt.image.BufferedImage;
  * @author Mitchell Skaggs
  */
 public class HeadlessNES {
+    
+    private HeadlessNES() {}
+    
     public static final int scale = 4;
     public static void main(String[] args) {
         BufferedImage bufferedImage = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB_PRE);

--- a/src/main/java/com/grapeshot/halfnes/halfNES.java
+++ b/src/main/java/com/grapeshot/halfnes/halfNES.java
@@ -11,7 +11,7 @@ import javax.swing.*;
 
 public class halfNES {
 
-
+    private halfNES() {}
 
     public static void main(String[] args) throws IOException {
         JInputHelper.setupJInput();

--- a/src/main/java/com/grapeshot/halfnes/mappers/NSFPlayerFont.java
+++ b/src/main/java/com/grapeshot/halfnes/mappers/NSFPlayerFont.java
@@ -9,6 +9,8 @@ package com.grapeshot.halfnes.mappers;
  * @author Andrew
  */
 public class NSFPlayerFont {
+    
+    private NSFPlayerFont() {}
 
     //file auto-generated from Dwedit's ascii.chr by bin2h.exe
 

--- a/src/main/java/com/grapeshot/halfnes/utils.java
+++ b/src/main/java/com/grapeshot/halfnes/utils.java
@@ -8,6 +8,8 @@ import java.util.Locale;
 
 public class utils {
 
+    private utils() {}
+    
     public final static int BIT0 = 1, BIT1 = 2, BIT2 = 4, BIT3 = 8, BIT4 = 16,
             BIT5 = 32, BIT6 = 64, BIT7 = 128, BIT8 = 256, BIT9 = 512,
             BIT10 = 1024, BIT11 = 2048, BIT12 = 4096, BIT13 = 8192,

--- a/src/main/java/com/grapeshot/halfnes/video/NesColors.java
+++ b/src/main/java/com/grapeshot/halfnes/video/NesColors.java
@@ -10,6 +10,8 @@ package com.grapeshot.halfnes.video;
  */
 public class NesColors {
 
+    private NesColors() {}
+    
     private final static double att = 0.7;
     public final static int[][] col = GetNESColors();
     public final static byte[][][] colbytes = NESColorsToBytes(col);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed