### PR TITLE
Code quality fix - Local Variables should not be declared and then immediately returned or thrown.

### DIFF
--- a/src/main/java/com/grapeshot/halfnes/audio/Namco163SoundChip.java
+++ b/src/main/java/com/grapeshot/halfnes/audio/Namco163SoundChip.java
@@ -74,8 +74,7 @@ public class Namco163SoundChip implements ExpansionSoundChip {
 
     private int getWavefromRAM(final int addr) {
         final int b = registers[(addr) >> 1];
-        int r = ((addr & (utils.BIT0)) != 0) ? b >> 4 : b & 0xf;
-        return r;
+        return ((addr & (utils.BIT0)) != 0) ? b >> 4 : b & 0xf;
     }
 
     @Override

--- a/src/main/java/com/grapeshot/halfnes/audio/Sunsoft5BSoundChip.java
+++ b/src/main/java/com/grapeshot/halfnes/audio/Sunsoft5BSoundChip.java
@@ -79,10 +79,9 @@ public class Sunsoft5BSoundChip implements ExpansionSoundChip {
     }
 
     public final int getval() {
-        final int mixvol = (enable[0] ? ((useenvelope[0] ? enval : volumetbl[volume[0]]) * timers[0].getval()) : 0)
+        return (enable[0] ? ((useenvelope[0] ? enval : volumetbl[volume[0]]) * timers[0].getval()) : 0)
                 + (enable[1] ? ((useenvelope[1] ? enval : volumetbl[volume[1]]) * timers[1].getval()) : 0)
                 + (enable[2] ? ((useenvelope[2] ? enval : volumetbl[volume[2]]) * timers[2].getval()) : 0);
-        return mixvol;
     }
 
     public static int[] getvoltbl() {

--- a/src/main/java/com/grapeshot/halfnes/audio/VRC6SoundChip.java
+++ b/src/main/java/com/grapeshot/halfnes/audio/VRC6SoundChip.java
@@ -74,10 +74,9 @@ public class VRC6SoundChip implements ExpansionSoundChip {
     }
 
     public final int getval() {
-        final int mixvol = 320 * (((enable[0] ? volume[0] : 0) * timers[0].getval()
+        return 320 * (((enable[0] ? volume[0] : 0) * timers[0].getval()
                 + (enable[1] ? volume[1] : 0) * timers[1].getval())
                 + (enable[2] ? ((volume[2] & 0xff) >> 3) : 0));
-        return mixvol;
     }
 
     private void clocksaw() {

--- a/src/main/java/com/grapeshot/halfnes/audio/VRC7SoundChip.java
+++ b/src/main/java/com/grapeshot/halfnes/audio/VRC7SoundChip.java
@@ -311,8 +311,7 @@ public class VRC7SoundChip implements ExpansionSoundChip {
         int mantissa = exp[(-val & 0xff)];
         int exponent = (-val) >> 8;
 //        int a = (int) Math.scalb(mantissa + 1024, exponent) * s; //correct but slow
-        int b = ((((mantissa + 1024) >> (-exponent)))) * s; //not correct for negative #s
-        return b;
+        return ((((mantissa + 1024) >> (-exponent)))) * s; //not correct for negative #s
     }
     private int s; // ugly hackish sign flag
 

--- a/src/main/java/com/grapeshot/halfnes/video/CombFiltered.java
+++ b/src/main/java/com/grapeshot/halfnes/video/CombFiltered.java
@@ -217,9 +217,7 @@ public class CombFiltered extends Renderer {
         for (int line = 0; line < 240; ++line) {
             ntsc_decode(ntsc_encode(nespixels, line * 256, bgcolor[line], dotcrawl), frame, line * frame_w);
         }
-        BufferedImage i = getImageFromArray(frame, frame_w * 8, frame_w, 224);
-
-        return i;
+        return getImageFromArray(frame, frame_w * 8, frame_w, 224);
     }
 
     public final void cap_filter(final double[] in, final double[] out, final double rc) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.
 
Faisal Hameed