### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Controller 1:
 
 The keys mapped to the A and B buttons are used to change tracks in the NSF player.
 
-#Note on joystick support
+# Note on joystick support
 
 The first detected gamepad will be used as Controller 1, and the second 
 will be Controller 2. Currently the buttons used are not configurable. 
 (the controller needs to be plugged in before a game is loaded in order to be detected.)
 
-#Compatibility
+# Compatibility
 
 At this point in 
 development, almost all US released games will start, but certain games 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
